### PR TITLE
feat: improve manifest refresh UX (loading, error, success) (#7)

### DIFF
--- a/apps/admin/src/modules/plugins/components/PluginForm.vue
+++ b/apps/admin/src/modules/plugins/components/PluginForm.vue
@@ -25,7 +25,7 @@
               <span>{{ $t('Basic Information') }}</span>
             </div>
           </template>
-          <BasicInfoTab :plugin="edit" @refresh-manifest="refreshPluginFromManifest" />
+          <BasicInfoTab :plugin="edit" :is-refreshing="isRefreshing" :last-error="lastError" @refresh-manifest="refreshPluginFromManifest" @retry="retryRefresh"/>
         </el-tab-pane>
         
         <el-tab-pane name="apis" lazy>
@@ -98,9 +98,10 @@
   </el-form>
 </template>
 <script setup lang="ts">
-import { computed, provide, reactive } from 'vue';
+import { computed, provide, reactive, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { IPlugin } from '@/services/types/plugin';
+import { ElMessage } from 'element-plus';
 import {
   BasicInfoTab,
   APIsTab,
@@ -119,6 +120,10 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'submitted', plugin: Partial<IPlugin>): void;
 }>();
+
+//flags
+const isRefreshing = ref(false) // control spinner/ disable button on refresh
+const lastError = ref<string | null>(null) //stores the last refresh error
 
 const route = useRoute();
 const router = useRouter();
@@ -143,8 +148,10 @@ provide('plugin', edit);
 
 // Refresh plugin from manifest
 async function refreshPluginFromManifest() {
-  if (!edit.manifestUrl) return;
+  if (!edit.manifestUrl || isRefreshing.value) return;
   
+  isRefreshing.value = true; // turn the spinner on and disable button
+  lastError.value = null // clear previous error state
   try {
     const response = await fetch(edit.manifestUrl);
     if (!response.ok) {
@@ -162,9 +169,21 @@ async function refreshPluginFromManifest() {
       edit.apiPath = manifest.name.toLowerCase().replace(/\s+/g, '-');
     }
     submit();
-  } catch (error) {
-    console.error('Error fetching manifest:', error);
+  } catch (e: any) {
+    //visible, dismissible error message
+    lastError.value = e?.message || 'Refresh failed'
+    ElMessage.error({
+      message: lastError.value,
+      showClose: true,      
+      duration: 5000        // time until dissapears
+    })
+  }finally {
+    isRefreshing.value = false;     // stop spinner (success or error)
   }
+}
+
+function retryRefresh() {
+  refreshPluginFromManifest()
 }
 
 // Update plugin JSON from the Summary tab

--- a/apps/admin/src/modules/plugins/components/plugin-form/BasicInfoTab.vue
+++ b/apps/admin/src/modules/plugins/components/plugin-form/BasicInfoTab.vue
@@ -25,11 +25,17 @@
         <FormInput title="Plugin API Path" label="Leave empty to auto-set" v-model="plugin.apiPath"/>
       </FormRowGroup>
       <div class="refresh-button-container">
-        <el-button type="primary" class="refresh-button" @click="refreshPluginFromManifest">
-          <el-icon>
+        <!-- Single button handling all states -->
+        <el-button type="primary" class="refresh-button" :loading="props.isRefreshing" :disabled="props.isRefreshing" @click="props.lastError ? retryRefresh() : refreshPluginFromManifest()">
+          <!-- Only show sync icon if not in loading state -->
+          <el-icon v-if="!props.isRefreshing">
             <font-awesome-icon :icon="['fas', 'sync']" />
           </el-icon>
-          <span>{{ $t('Refresh from Manifest') }}</span>
+          <span><!-- Span by state -->
+            <template v-if="props.isRefreshing">Loading…</template>
+            <template v-else-if="props.lastError">Retry</template>
+            <template v-else>Refresh from Manifest</template>
+          </span>
         </el-button>
       </div>
     </el-card>
@@ -41,15 +47,23 @@ import FormInput from '@/modules/core/components/forms/FormInput.vue';
 import FormRowGroup from '@/modules/core/components/forms/FormRowGroup.vue';
 import { IPlugin } from '@/services/types/plugin';
 
+//added props to receive UX state
 const props = defineProps<{
-  plugin: Partial<IPlugin>;
+  plugin: Partial<IPlugin>,
+  isRefreshing?: boolean,
+  lastError?: string | null
 }>();
 
 const emit = defineEmits<{
-  (e: 'refreshManifest'): void;
+  (e: 'refresh-manifest'): void
+  (e: 'retry'): void
 }>();
 
 function refreshPluginFromManifest() {
-  emit('refreshManifest');
+  emit('refresh-manifest');
+}
+
+function retryRefresh(){
+  emit('retry');
 }
 </script>


### PR DESCRIPTION
Improved the UX for the Plugin Refresh from Manifest process to provide better feedback during loading and error states.

- Added loading spinner and disabled state for the refresh button during request.
- Added ElMessage.error with a clear and accessible error message on failure.
- Introduced a retry button with replacing the main button after an error.
- Unified the loading phase for both initial refresh and retry actions.

The functionality fully matches the acceptance criteria from issue #7.