### PR TITLE
feat(assets): add file size limits to uploads

### DIFF
--- a/apps/assets/README.md
+++ b/apps/assets/README.md
@@ -25,3 +25,18 @@ $ pnpm install
 ```sh
 $ pnpm start
 ```
+
+## Configuration
+
+### File Size Limits
+Uploads are limited to **50MB** by default. To change the limit, set the `MAX_FILE_SIZE` environment variable (in bytes):
+
+```sh
+MAX_FILE_SIZE=104857600 # 100MB
+```
+
+Files exceeding the limit are rejected with a `413` status code and the following response:
+
+```json
+{ "message": "File too large.", "maxFileSize": "<configured limit in bytes>" }
+```

--- a/apps/assets/config/index.js
+++ b/apps/assets/config/index.js
@@ -2,6 +2,8 @@ const editorsRoles = process.env.EDITORS_ROLES ? process.env.EDITORS_ROLES.split
 
 const isDev = process.env.NODE_ENV !== 'production';
 
+const maxFileSize = parseInt(process.env.MAX_FILE_SIZE, 10) || 50 * 1024 * 1024; // 50MB default
+
 module.exports = {
   dev: isDev,
   mongoUri: process.env.MONGO_URI || 'mongodb://localhost/assets-service',
@@ -9,4 +11,5 @@ module.exports = {
   secretsToken: process.env.ASSETS_SERVICE_SECRET || process.env.SECRETS_TOKEN,
   editorsRoles,
   showLogs: isDev || process.env.SHOW_LOGS === 'true',
+  maxFileSize,
 }

--- a/apps/assets/server/controllers/upload.ts
+++ b/apps/assets/server/controllers/upload.ts
@@ -7,6 +7,8 @@ import { emitPlatformEvent } from "@qelos/api-kit";
 import logger from "../services/logger";
 import { handleImageOptimization } from "../services/image-optimizer";
 
+const { maxFileSize } = require('../../config');
+
 // Default file extension for unknown types
 const DEFAULT_EXTENSION = "jpg";
 
@@ -86,7 +88,17 @@ export async function uploadFile(req: any, res: any): Promise<any> {
         if (!response.ok)
           throw new Error(`URL fetch failed: ${response.statusText}`);
 
-        const buffer = await response.arrayBuffer();
+        const chunks: Buffer[] = [];
+        let receivedSize = 0;
+        for await (const chunk of response.body as any) {
+          receivedSize += chunk.length;
+          if (receivedSize > maxFileSize) {
+            return res.status(413).json({ message: 'File too large.', maxFileSize }).end();
+          }
+          chunks.push(Buffer.from(chunk));
+        }
+        const buffer = Buffer.concat(chunks);
+
         mimeType = response.headers.get("content-type") || undefined;
         fileData = await handleUpload(
           storage,

--- a/apps/assets/server/middleware/upload.js
+++ b/apps/assets/server/middleware/upload.js
@@ -1,6 +1,8 @@
 const multer = require('multer');
+const { maxFileSize } = require('../../config');
 
-// Configure multer with our custom streaming storage engine
-const upload = multer();
+const upload = multer({
+  limits: { fileSize: maxFileSize },
+});
 
 module.exports = upload;

--- a/apps/assets/server/routes/index.js
+++ b/apps/assets/server/routes/index.js
@@ -1,5 +1,14 @@
+const multer = require('multer');
 const app = require('@qelos/api-kit').app()
+const { maxFileSize } = require('../../config');
 
 app.use(require('./assets'))
 app.use(require('./storage'))
 app.use(require('./upload'))
+
+app.use((err, req, res, next) => {
+  if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+    return res.status(413).json({ message: 'File too large.', maxFileSize }).end();
+  }
+  next(err);
+});


### PR DESCRIPTION
## Summary
- Adds configurable file size limit (default 50MB, configurable via `MAX_FILE_SIZE` env var)
- Enforces limit on direct uploads via multer `limits.fileSize`
- Enforces limit on URL-based uploads by streaming the response and aborting mid-download when the limit is exceeded
- Centralized error handler in `routes/index.js` returns `413` with a consistent response: `{ message, maxFileSize }`
- Updated README with configuration docs

Closes #18