### PR TITLE
feat(api-kit): add timeout handling and retry with exponential backoff

### DIFF
--- a/packages/api-kit/README.md
+++ b/packages/api-kit/README.md
@@ -11,3 +11,51 @@ This code brings together all Qelos services
 ### Auth Middlewares
 
 `api-kit` provides simple authentication middlewares from the authentication service, without having to worry about fetching.
+
+### Internal Service Communication
+
+`api-kit` provides `service()` and `callInternalService()` for service-to-service HTTP calls with built-in timeout and retry handling.
+
+#### Timeout
+
+All requests have a default timeout of 30 seconds. Configure globally via environment variable or per request:
+
+```
+INTERNAL_SERVICE_TIMEOUT=60000
+```
+
+```ts
+contentService({ method: 'GET', url: '/api/data', timeout: 10000 })
+```
+
+Timeout errors are logged: `[api-kit] GET /api/data timed out after 10000ms`
+
+#### Retry
+
+Requests automatically retry up to 3 times on connection errors (ECONNREFUSED, ECONNRESET) with exponential backoff (200ms, 400ms, 800ms).
+
+Configure globally:
+```
+INTERNAL_SERVICE_RETRIES=5
+INTERNAL_SERVICE_RETRY_DELAY=500
+```
+
+Or per request:
+```ts
+contentService({ method: 'GET', url: '/api/data', retries: 5, retryDelay: 500 })
+```
+
+To disable retries:
+```ts
+contentService({ method: 'POST', url: '/api/events', retries: 0 })
+```
+
+#### Retrying on HTTP status codes
+
+By default, retries only happen on connection errors. To also retry on specific HTTP status codes (e.g. for idempotent GET requests), pass `retryableStatusCodes`:
+
+```ts
+contentService({ method: 'GET', url: '/api/data', retryableStatusCodes: [502, 503, 504] })
+```
+
+This is opt-in because retrying non-idempotent requests (POST, PUT) on server errors could cause duplicate operations.

--- a/packages/api-kit/src/internal-service.ts
+++ b/packages/api-kit/src/internal-service.ts
@@ -1,8 +1,29 @@
-import axios, { AxiosPromise, AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import type { Service, ServiceProtocol } from './types';
 
-export function service(name: string, descriptorOverrides: Partial<Service> = {}): (options: AxiosRequestConfig) => AxiosPromise {
+const DEFAULT_TIMEOUT = parseInt(process.env.INTERNAL_SERVICE_TIMEOUT, 10) || 30000;
+const DEFAULT_MAX_RETRIES = parseInt(process.env.INTERNAL_SERVICE_RETRIES, 10) || 3;
+const DEFAULT_RETRY_DELAY = parseInt(process.env.INTERNAL_SERVICE_RETRY_DELAY, 10) || 200;
+
+interface InternalServiceOptions extends AxiosRequestConfig {
+  retries?: number;
+  retryDelay?: number;
+  retryableStatusCodes?: number[];
+}
+
+function isRetryable(error: any, retryableStatusCodes: number[]): boolean {
+  if (error.code === 'ECONNREFUSED') return true;
+  if (error.code === 'ECONNRESET') return true;
+  if (retryableStatusCodes.length && error.response && retryableStatusCodes.includes(error.response.status)) return true;
+  return false;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function service(name: string, descriptorOverrides: Partial<Service> = {}): (options: InternalServiceOptions) => Promise<AxiosResponse> {
   const service = createServiceDescriptor(name, descriptorOverrides);
 
   return (options) => callInternalService(service, options);
@@ -18,10 +39,39 @@ function createServiceDescriptor(name: string, descriptorOverrides: Partial<Serv
   };
 }
 
-export function callInternalService(service: Service, options: AxiosRequestConfig): AxiosPromise {
-  return axios({
-    ...options,
-    url: `${service.protocol}://${service.url}:${service.port}${options.url}`,
-    timeout: options.timeout || 30000, // 30 second default timeout
-  });
+export async function callInternalService(service: Service, options: InternalServiceOptions): Promise<AxiosResponse> {
+  const {
+    retries = DEFAULT_MAX_RETRIES,
+    retryDelay = DEFAULT_RETRY_DELAY,
+    retryableStatusCodes = [],
+    timeout = DEFAULT_TIMEOUT,
+    ...axiosOptions
+  } = options;
+
+  const method = options.method || 'GET';
+  const url = `${service.protocol}://${service.url}:${service.port}${options.url}`;
+  let lastError: any;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await axios({ ...axiosOptions, url, timeout });
+    } catch (error: any) {
+      lastError = error;
+
+      if (attempt < retries && isRetryable(error, retryableStatusCodes)) {
+        const delay = retryDelay * Math.pow(2, attempt);
+        console.warn(`[api-kit] ${method} ${options.url} failed (attempt ${attempt + 1}/${retries + 1}): ${error.message}. Retrying in ${delay}ms...`);
+        await sleep(delay);
+        continue;
+      }
+
+      if (error.code === 'ECONNABORTED') {
+        console.error(`[api-kit] ${method} ${options.url} timed out after ${timeout}ms`);
+      }
+
+      throw error;
+    }
+  }
+
+  throw lastError;
 }


### PR DESCRIPTION
## Summary
- Configurable request timeouts via `INTERNAL_SERVICE_TIMEOUT` env var (default 30s) or per-call `timeout` option
- Automatic retry with exponential backoff on connection errors (ECONNREFUSED, ECONNRESET)
- Configurable max retries via `INTERNAL_SERVICE_RETRIES` env var (default 3) or per-call `retries` option
- Opt-in `retryableStatusCodes` option for retrying on specific HTTP status codes (off by default to avoid retrying non-idempotent requests)
- Logging for timeout events and retry attempts
- Updated README with configuration docs

Closes #20
Closes #21