### PR TITLE
fix(auth): fix profile image upload error handling in social logins

### DIFF
--- a/apps/auth/server/services/assets-service-api.ts
+++ b/apps/auth/server/services/assets-service-api.ts
@@ -10,26 +10,22 @@ export async function uploadProfileImage(
   userId: string,
   imageUrl: string
 ): Promise<string> {
-  try {
-    const response = await assetsService({
-      method: "POST",
-      url: "/api/upload",
-      headers: {
-        tenant,
-        user: JSON.stringify({ _id: userId })
-      },
-      data: {
-        url: imageUrl,
-      },
-    });
+  const response = await assetsService({
+    method: "POST",
+    url: "/api/upload",
+    headers: {
+      tenant,
+      user: JSON.stringify({ _id: userId })
+    },
+    data: {
+      url: imageUrl,
+    },
+  });
 
-    if (response.status === 200) {
-      return response.data.publicUrl;
-    } else {
-      logger.log("Failed to upload profile image", response.data);
-      throw new Error("Failed to upload profile image");
-    }
-  } catch (error) {
-    throw error;
+  if (response.status === 200 && response.data.publicUrl) {
+    return response.data.publicUrl;
   }
+
+  logger.error("Failed to upload profile image", { tenant, userId, status: response.status, data: response.data });
+  throw new Error("Failed to upload profile image");
 }

--- a/apps/auth/server/services/social-login-service.ts
+++ b/apps/auth/server/services/social-login-service.ts
@@ -154,6 +154,7 @@ export async function findOrCreateUser(
       try {
         profileImage = await uploadProfileImage(tenant, tempUserId, userData.picture);
       } catch (error) {
+        logger.error('failed to upload profile image for new user', error);
         profileImage = userData.picture;
       }
     }


### PR DESCRIPTION
## Summary
- Removed redundant try/catch in `uploadProfileImage` that only re-threw the error
- Changed `logger.log` to `logger.error` with structured context (tenant, userId, status) for failed uploads
- Added check for missing `publicUrl` in successful responses
- Added missing error logging when profile image upload fails for new users (existing users already had it)

Closes #15