### PR TITLE
feat(api-kit): add standardized error handler middleware

### DIFF
--- a/apps/ai/server/routes/index.ts
+++ b/apps/ai/server/routes/index.ts
@@ -1,4 +1,4 @@
-import { app as getApp } from '@qelos/api-kit'
+import { app as getApp, errorHandler } from '@qelos/api-kit'
 import { chatCompletionRouter } from './chat-completion'
 import { sourcesChatCompletionRouter } from './sources-chat-completion'
 import { threadsRouter } from './threads'
@@ -8,4 +8,5 @@ export async function loadRoutes() {
   app.use(sourcesChatCompletionRouter())
   app.use(chatCompletionRouter())
   app.use(threadsRouter())
+  app.use(errorHandler)
 }

--- a/apps/assets/server/routes/index.js
+++ b/apps/assets/server/routes/index.js
@@ -1,5 +1,8 @@
 const app = require('@qelos/api-kit').app()
+const { errorHandler } = require('@qelos/api-kit')
 
 app.use(require('./assets'))
 app.use(require('./storage'))
 app.use(require('./upload'))
+
+app.use(errorHandler)

--- a/apps/auth/server/routes/index.ts
+++ b/apps/auth/server/routes/index.ts
@@ -6,6 +6,7 @@ import workspaceRouter from './workspace';
 import apiTokensRouter from './api-tokens';
 
 const app = require('@qelos/api-kit').app();
+const { errorHandler } = require('@qelos/api-kit');
 app.use(require('cookie-parser')());
 
 app.use(apiTokensRouter)
@@ -14,3 +15,5 @@ app.use(invitesRouter)
 app.use(usersRouter);
 app.use(authRouter);
 app.use(workspaceRouter);
+
+app.use(errorHandler);

--- a/apps/content/server/routes/index.js
+++ b/apps/content/server/routes/index.js
@@ -1,5 +1,8 @@
 const app = require('@qelos/api-kit').app()
+const { errorHandler } = require('@qelos/api-kit')
 
 require('./configurations')(app);
 require('./blocks')(app);
 require('./tenants-configurations')(app);
+
+app.use(errorHandler)

--- a/apps/drafts/server/routes/index.ts
+++ b/apps/drafts/server/routes/index.ts
@@ -1,5 +1,7 @@
-import { app as getApp } from "@qelos/api-kit";
+import { app as getApp, errorHandler } from "@qelos/api-kit";
 import draftRoutes from "./drafts";
 
 const app = getApp();
 draftRoutes(app);
+
+app.use(errorHandler);

--- a/apps/no-code/server/routes/index.ts
+++ b/apps/no-code/server/routes/index.ts
@@ -1,4 +1,4 @@
-import { app as getApp, config } from '@qelos/api-kit'
+import { app as getApp, config, errorHandler } from '@qelos/api-kit'
 import blueprintsRouter from './blueprints';
 import entitiesRouter from './entities';
 import chartsRouter from './charts';
@@ -15,3 +15,5 @@ app.use(entitiesRouter);
 app.use(chartsRouter);
 app.use(blueprintsRouter);
 app.use(componentsRouter);
+
+app.use(errorHandler);

--- a/apps/payments/server/routes/index.ts
+++ b/apps/payments/server/routes/index.ts
@@ -5,9 +5,12 @@ import couponsRouter from './coupons';
 import checkoutRouter from './checkout';
 
 const app = require('@qelos/api-kit').app();
+const { errorHandler } = require('@qelos/api-kit');
 
 app.use(plansRouter);
 app.use(subscriptionsRouter);
 app.use(invoicesRouter);
 app.use(couponsRouter);
 app.use(checkoutRouter);
+
+app.use(errorHandler);

--- a/apps/plugins/server/routes/index.ts
+++ b/apps/plugins/server/routes/index.ts
@@ -1,4 +1,4 @@
-import { app as getApp } from '@qelos/api-kit'
+import { app as getApp, errorHandler } from '@qelos/api-kit'
 import { managePlugins } from './manage-plugins';
 import { playPlugins } from './play-plugins';
 import eventsRouter from './events';
@@ -20,4 +20,5 @@ export async function loadRoutes() {
   app.use(dataManipulationRouter());
   app.use(lambdasRouter());
   app.use(webhooksRouter());
+  app.use(errorHandler);
 }

--- a/apps/secrets/server/routes/index.js
+++ b/apps/secrets/server/routes/index.js
@@ -1,4 +1,5 @@
 const app = require('@qelos/api-kit').app()
+const { errorHandler } = require('@qelos/api-kit')
 const internalCheck = require('../middleware/internal-call-check')
 
 app.use(internalCheck)
@@ -6,3 +7,5 @@ app.use(internalCheck)
 app
   .post('/api/secrets/get', require('../controllers/get'))
   .post('/api/secrets/set', require('../controllers/set'))
+
+app.use(errorHandler)

--- a/packages/api-kit/src/error-handler.ts
+++ b/packages/api-kit/src/error-handler.ts
@@ -1,0 +1,24 @@
+import type { Request, Response, NextFunction } from 'express';
+import { ResponseError } from './response-error';
+
+export function errorHandler(err: any, req: Request, res: Response, next: NextFunction) {
+  if (res.headersSent) {
+    console.error(`[${req.method}] ${req.path} — error after headers sent:`, err);
+    res.end();
+    return;
+  }
+
+  if (err instanceof ResponseError) {
+    return res.status(err.status).json({
+      message: err.responseMessage,
+      code: err.status,
+    }).end();
+  }
+
+  console.error(`[${req.method}] ${req.path} — unhandled error:`, err);
+
+  return res.status(500).json({
+    message: 'Internal server error',
+    code: 500,
+  }).end();
+}

--- a/packages/api-kit/src/index.ts
+++ b/packages/api-kit/src/index.ts
@@ -5,4 +5,5 @@ export * from './internal-service'
 export * from './user-middlewares'
 export * from './emit-internal-event'
 export * from './response-error';
+export * from './error-handler';
 export * from './request-utils';


### PR DESCRIPTION
## Summary
- Created `errorHandler` middleware in api-kit with consistent error response format `{ message, code }`
- ResponseError instances return their status and message
- Unhandled errors return generic 500 with no sensitive info leaked, real error logged server-side
- Wired into all 9 services

Closes #12