### PR TITLE
fix(assets): use upload.single instead of upload.any in assets route

### DIFF
--- a/apps/assets/server/controllers/assets.js
+++ b/apps/assets/server/controllers/assets.js
@@ -31,7 +31,7 @@ function getStorageAssets(req, res) {
 }
 
 function uploadStorageAssets(req, res) {
-  const fileData = req.files[0];
+  const fileData = req.file;
   const type = fileData.mimetype;
   const { identifier, extension, prefix } = req.query || {};
   const tenant = req.headers.tenant;

--- a/apps/assets/server/routes/assets.js
+++ b/apps/assets/server/routes/assets.js
@@ -15,7 +15,7 @@ const AUTH_MIDDLEWARES = [populateUser, verifyUser, editorCheck]
 
 router
   .get('/api/assets/:storageId', [...AUTH_MIDDLEWARES, getStorageById, getStorageAssets])
-  .post('/api/assets/:storageId', [...AUTH_MIDDLEWARES, getStorageById, verifyIdentifier, upload.any(), uploadStorageAssets])
+  .post('/api/assets/:storageId', [...AUTH_MIDDLEWARES, getStorageById, verifyIdentifier, upload.single('file'), uploadStorageAssets])
   .put('/api/assets/:storageId', [...AUTH_MIDDLEWARES, getStorageById, verifyIdentifier, renameStorageAssets])
   .delete('/api/assets/:storageId', [...AUTH_MIDDLEWARES, getStorageById, verifyIdentifier, removeStorageAsset]);
 


### PR DESCRIPTION
## Summary
- Changed `upload.any()` to `upload.single('file')` in the assets upload route
- Changed `req.files[0]` to `req.file` in the controller

The handler only processes one file, so `upload.any()` was unnecessarily accepting multiple files while ignoring all but the first.

Closes #87