### PR TITLE
Builder menu can’t scroll down in mobile

### DIFF
--- a/apps/admin/src/modules/builder/components/BuilderNavigationDrawer.vue
+++ b/apps/admin/src/modules/builder/components/BuilderNavigationDrawer.vue
@@ -383,7 +383,7 @@ async function handleLogout() {
   
   .drawer-content {
     position: relative;
-    height: 100vh;
+    height: 100%;
     background: var(--el-bg-color);
     border-right: 1px solid var(--el-border-color);
     pointer-events: all;


### PR DESCRIPTION
Implements: https://app.clickup.com/t/86c9b3p0h

Automated PR by aidev.